### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# demo
+
+
+
+We cannot implicitly convert type int or string to enum.
+Therefore we need to convert it explicitly by using a cast.
+So we can assign it in either ways:
+MessageType = Enum.Parse("Transaction),
+OR
+MessageType = (SystemMessageType)2,


### PR DESCRIPTION
We cannot implicitly convert type int or string to enum.
Therefore we need to convert it explicitly by using a cast.
So we can assign it in either ways:
MessageType = Enum.Parse<SystemMessageType>("Transaction),
OR
MessageType = (SystemMessageType)2,